### PR TITLE
Sparse Checkout for Action Files in Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: mkdir-action
+          sparse-checkout: action.yaml
 
       # Modify the following steps for testing your composite action.
       # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          path: mkdir-action
 
       # Modify the following steps for testing your composite action.
       # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests
@@ -24,7 +26,7 @@ jobs:
         run: "! test -d dir"
 
       - name: Create test directory
-        uses: ./
+        uses: ./mkdir-action
         with:
           name: dir
 


### PR DESCRIPTION
This pull request modifies the checkout step in the `test` job of `ci.yaml` workflow as follows:
- Checkout to `mkdir-action` directory instead to default current directory.
- Sparse checkout `action.yaml` file  only instead of the whole files.

It closes #13.