### PR TITLE
Rename CI Workflow to Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,12 @@
-name: CI
+name: Test
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  test:
-    name: Test
+  test-action:
+    name: Test Action
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,15 +22,15 @@ jobs:
       # Modify the following steps for testing your composite action.
       # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests
 
-      - name: Test directory should not exist
+      - name: Directory Should Not Exist
         shell: bash
         run: "! test -d dir"
 
-      - name: Create test directory
+      - name: Create Directory
         uses: ./mkdir-action
         with:
           name: dir
 
-      - name: Test directory should exist
+      - name: Directory Should Exist
         shell: bash
         run: test -d dir

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![version](https://img.shields.io/github/v/release/threeal/composite-action-starter?style=flat-square)](https://github.com/threeal/composite-action-starter/releases)
 [![license](https://img.shields.io/github/license/threeal/composite-action-starter?style=flat-square)](./LICENSE)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/composite-action-starter/ci.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/composite-action-starter/actions/workflows/ci.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/composite-action-starter/test.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/composite-action-starter/actions/workflows/test.yaml)
 
 The Composite Action Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [GitHub composite action](https://github.com/features/actions) project.
 Use this template to initialize your project with predefined file structures and preconfigured settings recommended for a GitHub composite action project.


### PR DESCRIPTION
This pull request resolves #14 by renaming the `ci.yaml` workflow to `test.yaml` workflow. This change also rename the action, jobs, and steps respectively.