### PR TITLE
Disable Cone Mode in Sparse Checkout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           path: mkdir-action
           sparse-checkout: action.yaml
+          sparse-checkout-cone-mode: false
 
       # Modify the following steps for testing your composite action.
       # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests


### PR DESCRIPTION
This pull request disables the cone mode during a sparse checkout. See https://github.com/threeal/yarn-install-action/pull/31 for the reason behind this change.