### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 
 # Composite Action Starter
 
-[![version](https://img.shields.io/github/v/release/threeal/composite-action-starter?style=flat-square)](https://github.com/threeal/composite-action-starter/releases)
-[![license](https://img.shields.io/github/license/threeal/composite-action-starter?style=flat-square)](./LICENSE)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/composite-action-starter/test.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/composite-action-starter/actions/workflows/test.yaml)
-
 The Composite Action Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [GitHub composite action](https://github.com/features/actions) project.
 Use this template to initialize your project with predefined file structures and preconfigured settings recommended for a GitHub composite action project.
 


### PR DESCRIPTION
This pull request resolves #23 by simply removing badges from the root `README.md` file.